### PR TITLE
Allow dm tags in /dm command

### DIFF
--- a/src/commands/internal.ts
+++ b/src/commands/internal.ts
@@ -204,6 +204,7 @@ export default function setupInternalCommands(app: App): void {
             return;
         }
 
+        args[0] = args[0].replace(/\D/g, "");
         if (app.client.users.cache.has(args[0])) {
             const recipient: User = app.client.users.cache.get(args[0]);
 


### PR DESCRIPTION
It removes any non-digit characters in the first argument in `/dm`.